### PR TITLE
Add webpack 5 as peer dependency

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Install and link main deps
         run: |
           npm install
+          npm install webpack@^5.65.0
           npm link
 
       - name: Install deps at tests folder

--- a/package.json
+++ b/package.json
@@ -8,5 +8,8 @@
   "license": "MIT",
   "dependencies": {
     "node-polyfill-webpack-plugin": "^1.1.4"
+  },
+  "peerDependencies": {
+    "webpack": ">=5"
   }
 }


### PR DESCRIPTION
It's required by `node-polyfill-webpack-plugin` and own plugin logic.
So, also installing it in CI tests environment.